### PR TITLE
Update Storybook addon metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "storybook-addon-sketch",
   "version": "0.2.1",
-  "description": "Get the sketch files for your stories in Storybook",
+  "description": "Get the sketch files for you stories in storybook",
   "main": "dist/index.js",
   "source": "src/index.js",
   "repository": {
@@ -101,5 +101,14 @@
     "skipReleaseLabels": [
       "dependency-update"
     ]
+  },
+  "keywords": [
+    "storybook-addon",
+    "design",
+    "popular"
+  ],
+  "storybook": {
+    "icon": "https://upload.wikimedia.org/wikipedia/commons/thumb/5/59/Sketch_Logo.svg/200px-Sketch_Logo.svg.png",
+    "displayName": "Sketch download"
   }
 }


### PR DESCRIPTION
Hey intuit! We've created a catalog of Storybook addons and yours is included: https://storybook.js.org/addons/storybook-addon-sketch

To make your addon more discoverable in the catalog, we've curated some of its metadata, and I've included those edits in this PR.

To learn more about the catalog metadata, check out our documentation: https://storybook.js.org/docs/react/addons/addon-catalog
